### PR TITLE
plotly-dash was too much in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ Include angular, plotly and angular-plotly:
 Add a chart:
 
 ```html
-<plotly plotly-data="data" plotly-layout="layout" plotly-options="options"></plotly>
+<plotly data="data" layout="layout" options="options"></plotly>
 ```
 
 The values expected for `data`, `layout` and `options` can be found in [plotly's documentation](https://plot.ly/javascript/).


### PR DESCRIPTION
the readme tutorial did not work for me
with official giraffes, orangutans, monkeys [20, 14, 23]  sample
if data is prefixed
