### PR TITLE
Added support of 'plotly-manual-data-update' directive attribute

### DIFF
--- a/src/angular-plotly.js
+++ b/src/angular-plotly.js
@@ -10,7 +10,8 @@
                     plotlyData: '=',
                     plotlyLayout: '=',
                     plotlyOptions: '=',
-                    plotlyEvents: '='
+                    plotlyEvents: '=',
+                    plotlyManualDataUpdate: '='
                 },
                 link: function(scope, element) {
                     var graph = element[0].children[0];
@@ -57,7 +58,8 @@
                             onUpdate();
                         }, true);
 
-                   scope.$watch(
+                    if (!scope.plotlyManualDataUpdate) {
+                        scope.$watch(
                             function(scope) {
                                 return scope.plotlyData;
                             },
@@ -65,6 +67,14 @@
                                 if (angular.equals(newValue, oldValue) && initialized) return;
                                 onUpdate();
                             }, true);
+                    }
+
+                    /**
+                     * Listens to 'tracesUpdated' event broadcasted from controller to update plot.
+                     */
+                    scope.$on('tracesUpdated', function () {
+                        onUpdate();
+                    });
 
                     scope.$watch(function() {
                         return {


### PR DESCRIPTION
In case of huge set of data provided in 'plotly-data' attribute value, using scope deep watcher becomes not really efficient, so my attempt to improve performance a bit was using new  'plotly-manual-data-update' directive attribute, which when set to 'true' causes not using scope watcher for chart data, but update only, when 'tracesUpdated' event is broadcasted from parent scope. So when we update chart data in controller, we can broadcast this event with:
`$scope.$broadcast('tracesUpdated');`
Where $scope is some custom controller scope. And 'plotly' directive will execute:

```
scope.$on('tracesUpdated', function () {
   onUpdate();
});
```
on this call.