### PR TITLE
 fix for issue #26

### DIFF
--- a/src/angular-plotly.js
+++ b/src/angular-plotly.js
@@ -44,7 +44,7 @@
                     }
 
                     function onResize() {
-			let graphDisplay = window.getComputedStyle(graph).display;
+                        let graphDisplay = window.getComputedStyle(graph).display;
                         if (!graphDisplay || (graphDisplay === "none") || !initialized || !scope.plotlyData)) return;
                         Plotly.Plots.resize(graph);
                     }

--- a/src/angular-plotly.js
+++ b/src/angular-plotly.js
@@ -44,7 +44,8 @@
                     }
 
                     function onResize() {
-                        if (!(initialized && scope.plotlyData)) return;
+						let graphDisplay = window.getComputedStyle(graph).display;
+                        if (!graphDisplay || (graphDisplay === "none") || !initialized || !scope.plotlyData)) return;
                         Plotly.Plots.resize(graph);
                     }
 

--- a/src/angular-plotly.js
+++ b/src/angular-plotly.js
@@ -44,7 +44,7 @@
                     }
 
                     function onResize() {
-						let graphDisplay = window.getComputedStyle(graph).display;
+			let graphDisplay = window.getComputedStyle(graph).display;
                         if (!graphDisplay || (graphDisplay === "none") || !initialized || !scope.plotlyData)) return;
                         Plotly.Plots.resize(graph);
                     }


### PR DESCRIPTION
Issue was called: 'Plotly error "Resize must be passed a displayed plot div element."'
This is an implementation of @gdurand's suggested fix. 
As stated [there](https://github.com/alonho/angular-plotly/issues/26), "I don't know if this has an impact on the onResize() functionality."