### PR TITLE
Fix infinite watcher recursion

### DIFF
--- a/src/angular-plotly.js
+++ b/src/angular-plotly.js
@@ -38,7 +38,9 @@
                               subscribeToEvents(graph);
                             }
                         }
-                        graph.layout = scope.plotlyLayout;
+                        // Copy the layout so that internal updates by plotly don't trigger the watcher, otherwise
+                        // we can end up in infinite watcher recursion -- this can happen when plotting time series data
+                        graph.layout = angular.copy(scope.plotlyLayout);
                         graph.data = scope.plotlyData;
                         Plotly.redraw(graph);
                         Plotly.Plots.resize(graph);


### PR DESCRIPTION
Make a copy of the layout before assigning it to the graph
element. Plotly sometimes performs its own updates on the layout
element, specifically when dealing with time series data where
the x-axis consists of Date values. In this case, we can get
into an infinite recursion situation with the watcher in
angular.